### PR TITLE
V2.5.2で変更するAPIのドキュメントの修正

### DIFF
--- a/docs/ExtensionFremeworkInterfaces/IApp.Events.cs
+++ b/docs/ExtensionFremeworkInterfaces/IApp.Events.cs
@@ -48,7 +48,7 @@ namespace LightningReview.ExtensionFramework
 		/// <summary>
 		/// レビューを開く前に発生します。
 		/// </summary>
-		event Action<object, ReviewCancelEventArgs> ReviewBeforeOpen;
+		event Action<object, ReviewBeforeOpenEventArgs> ReviewBeforeOpen;
 
 		/// <summary>
 		/// レビューを開く処理の開始時に発生します。

--- a/docs/References/Home.md
+++ b/docs/References/Home.md
@@ -49,6 +49,7 @@
 - [`ReviewAfterCloseEventArgs`](LightningReview.ExtensionFramework.md#reviewaftercloseeventargs)
 - [`ReviewCancelEventArgs`](LightningReview.ExtensionFramework.md#reviewcanceleventargs)
 - [`ReviewEventArgs`](LightningReview.ExtensionFramework.md#revieweventargs)
+- [`ReviewBeforeOpenEventArgs`](LightningReview.ExtensionFramework.md#reviewbeforeopeneventargs)
 - [`ReviewOnOpenEventArgs`](LightningReview.ExtensionFramework.md#reviewonopeneventargs)
 - [`ReviewOnSaveEventArgs`](LightningReview.ExtensionFramework.md#reviewonsaveeventargs)
 - [`ThemeHelper`](LightningReview.ExtensionFramework.md#themehelper)

--- a/docs/References/LightningReview.ExtensionFramework.md
+++ b/docs/References/LightningReview.ExtensionFramework.md
@@ -403,7 +403,7 @@ Events
 | `Action<Object, ReviewEventArgs>` | ReviewAfterOpen | レビューを開いた後に発生します。 | 
 | `Action<Object, ReviewEventArgs>` | ReviewAfterSave | レビューの保存後に発生します。 | 
 | `Action<Object, ReviewCancelEventArgs>` | ReviewBeforeClose | レビューが閉じる前に発生します。 | 
-| `Action<Object, ReviewCancelEventArgs>` | ReviewBeforeOpen | レビューを開く前に発生します。 | 
+| `Action<Object, ReviewBeforeOpenEventArgs>` | ReviewBeforeOpen | レビューを開く前に発生します。 | 
 | `Action<Object, ReviewCancelEventArgs>` | ReviewBeforeSave | レビューの保存前に発生します。 | 
 | `Action<Object, ReviewEventArgs>` | ReviewNew | レビューを新規作成すると発生します | 
 | `Action<Object, ReviewOnOpenEventArgs>` | ReviewOnOpen | レビューを開く処理の開始時に発生します。 | 
@@ -1203,6 +1203,22 @@ Properties
 | Type | Name | Summary | 
 | --- | --- | --- | 
 | `IReviewWindow` | ReviewWindow |  | 
+
+## `ReviewBeforeOpenEventArgs`
+
+レビューを開く前イベントのイベントパラメータ
+```csharp
+public class LightningReview.ExtensionFramework.ReviewBeforeOpenEventArgs
+    : CancelEventArgs
+
+```
+
+Properties
+
+| Type | Name | Summary | 
+| --- | --- | --- |  
+| `IReviewWindow` | ReviewWindow | レビューウィンドウを取得または設定します。 | 
+| `String` | ReviewFilePath | 開く対象のファイルパスを取得または設定します。 | 
 
 
 ## `ReviewOnOpenEventArgs`

--- a/version history/Changes in V2.5.2/V2.5.2.md
+++ b/version history/Changes in V2.5.2/V2.5.2.md
@@ -1,0 +1,18 @@
+# V2.5.2 の変更履歴
+
+### 既存のAPIの変更
+
+以下のAPI を変更しました。
+
+| No | API | 変更内容 | 
+| --- | --- | --- | 
+| 1 | AppOnReviewBeforeOpen | ReviewBeforeOpen イベントの第二引数を ReviewCancelEventArgs から ReviewBeforeOpenEventArgs に変更しました。 | 
+
+
+ReviewBeforeOpenを使用して拡張機能を作成している場合は以下の通り変更をお願いします。  
+・変更前  
+private void AppOnReviewBeforeOpen(object arg1, ReviewCancelEventArgs arg2)  
+
+・変更後  
+private void AppOnReviewBeforeOpen(object arg1, **ReviewBeforeOpneEventArgs** arg2)  
+

--- a/version history/Changes in V2.5.2/V2.5.2.md
+++ b/version history/Changes in V2.5.2/V2.5.2.md
@@ -6,7 +6,7 @@
 
 | No | API | 変更内容 | 
 | --- | --- | --- | 
-| 1 | AppOnReviewBeforeOpen | ReviewBeforeOpen イベントの第二引数を ReviewCancelEventArgs から ReviewBeforeOpenEventArgs に変更しました。 | 
+| 1 | AppOnReviewBeforeOpen | イベントの第二引数を ReviewCancelEventArgs から ReviewBeforeOpenEventArgs に変更しました。 | 
 
 
 ReviewBeforeOpenを使用して拡張機能を作成している場合は以下の通り変更をお願いします。  


### PR DESCRIPTION
This pull request includes changes to update the event argument type for the `ReviewBeforeOpen` event and document these changes across various files. The most important changes include updating the event argument type in the interface, updating references in documentation, and adding a new section to the version history.

### Event Argument Type Update:

* [`docs/ExtensionFremeworkInterfaces/IApp.Events.cs`](diffhunk://#diff-64f446612c0e9da7b1c03c7485f24220eaa08a371860d20a70003f7ff6a4df34L51-R51): Changed the event argument type for `ReviewBeforeOpen` from `ReviewCancelEventArgs` to `ReviewBeforeOpenEventArgs`.

### Documentation Updates:

* [`docs/References/Home.md`](diffhunk://#diff-80a841a6ecebead21207aaf190465604d29f47556682e619694fefa0e85bac43R52): Added `ReviewBeforeOpenEventArgs` to the list of event arguments.
* [`docs/References/LightningReview.ExtensionFramework.md`](diffhunk://#diff-426cb928566e7b3c8428d96933bd08fa8ace0b30836389438b0c83325c6fa4bfL406-R406): Updated the `Events` section to reflect the new event argument type for `ReviewBeforeOpen` and added a new section describing `ReviewBeforeOpenEventArgs`. [[1]](diffhunk://#diff-426cb928566e7b3c8428d96933bd08fa8ace0b30836389438b0c83325c6fa4bfL406-R406) [[2]](diffhunk://#diff-426cb928566e7b3c8428d96933bd08fa8ace0b30836389438b0c83325c6fa4bfR1207-R1222)

### Version History Update:

* [`version history/Changes in V2.5.2/V2.5.2.md`](diffhunk://#diff-62ffc1379bca066b77f6bac598ef8c15aef4cd3bd59ba8921a14ee008235790eR1-R18): Documented the change in the `ReviewBeforeOpen` event argument type and provided instructions for updating existing code.